### PR TITLE
Ajout de dependabot pour vérifier les dependances

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"  # "/" si Laravel est à la racine, sinon "/backend" ou "/backend/Laravel"
+    schedule:
+      interval: "daily"  # Dependabot vérifiera tous les jours les mises à jour


### PR DESCRIPTION
Dependabot va nous permettre de vérifier nos dépendaces laravel ou autre pour garder un bon niveau de sécurité.

Le fichier dependabot.yml est voué à être changé